### PR TITLE
make the type a checker is checking available

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -73,6 +73,10 @@ export declare class Checker {
      */
     getResult(): Checker;
     /**
+     * Return the type for which this is a checker.
+     */
+    getType(): TType;
+    /**
      * Actual implementation of check() and strictCheck().
      */
     private _doCheck(checkerFunc, value);

--- a/dist/index.js
+++ b/dist/index.js
@@ -138,6 +138,12 @@ class Checker {
         return new Checker(this.suite, this.ttype.result);
     }
     /**
+     * Return the type for which this is a checker.
+     */
+    getType() {
+        return this.ttype;
+    }
+    /**
      * Actual implementation of check() and strictCheck().
      */
     _doCheck(checkerFunc, value) {

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -129,6 +129,13 @@ export class Checker {
   }
 
   /**
+   * Return the type for which this is a checker.
+   */
+  public getType(): TType {
+    return this.ttype;
+  }
+
+  /**
    * Actual implementation of check() and strictCheck().
    */
   private _doCheck(checkerFunc: CheckerFunc, value: any): void {

--- a/test/test_checker.ts
+++ b/test/test_checker.ts
@@ -261,6 +261,6 @@ describe("ts-interface-checker", () => {
 
   it("should make type available", () => {
     const {Greeter} = createCheckers(greetTI);
-    assert(Greeter.getType() instanceof t.TIface);
+    assert.instanceOf(Greeter.getType(), t.TIface);
   });
 });

--- a/test/test_checker.ts
+++ b/test/test_checker.ts
@@ -258,4 +258,9 @@ describe("ts-interface-checker", () => {
     Greeter.methodResult("greet").check("hello");   // OK
     assert.throws(() => Greeter.methodResult("greet").check(null), /value is not a string/);
   });
+
+  it("should make type available", () => {
+    const {Greeter} = createCheckers(greetTI);
+    assert(Greeter.getType() instanceof t.TIface);
+  });
 });


### PR DESCRIPTION
Exposes the type the checker was made for.  Example use-case at: https://github.com/gristlabs/grain-rpc/blob/40f29b7ad9bce2b9d1dc4cc775caaaa7ac9c274e/lib/rpc.ts#L371