### PR TITLE
Compile to ES5 for maximum back compat

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,13 @@
 {
   "compilerOptions": {
-    "target": "es2016",
+    "target": "es5",
     "strict": true,
     "noUnusedLocals": true,
     "module": "commonjs",
     "baseUrl": ".",
     "outDir": "dist",
-    "declaration": true
+    "declaration": true,
+    "lib": ["es2015"]
   },
   "include": [
     "lib/*.ts"


### PR DESCRIPTION
In debugging an issue with using the UglifyJsPlugin for Webpack, we came to the realization that the dist files for ts-interface-checker are in ES2015, which means that there's a possibility that certain parsers still (*sigh*) will fail in using them. I'm proposing that we update the build to output ES5 to avoid issues in using ts-interface-checker with older Webpack builds or older browsers.