### PR TITLE
Fix VError inheritance from Error to preserve prototype chain

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -11,6 +11,8 @@ export {
   BasicType, ITypeSuite,
 } from "./types";
 
+export { VError, IErrorDetail } from './util';
+
 export interface ICheckerSuite {
   [name: string]: Checker;
 }

--- a/lib/util.ts
+++ b/lib/util.ts
@@ -5,6 +5,8 @@
 export class VError extends Error {
   constructor(public path: string, message: string) {
     super(message);
+    // See https://github.com/Microsoft/TypeScript/wiki/Breaking-Changes#extending-built-ins-like-error-array-and-map-may-no-longer-work for info about this workaround.
+    Object.setPrototypeOf(this, VError.prototype);
   }
 }
 

--- a/test/test_checker.ts
+++ b/test/test_checker.ts
@@ -1,5 +1,5 @@
 import {assert} from "chai";
-import {createCheckers} from "../lib/index";
+import {createCheckers, VError} from "../lib/index";
 import * as t from "../lib/types";
 import greetTI from "./fixtures/greet-ti";
 import sample from "./fixtures/sample-ti";
@@ -57,6 +57,7 @@ describe("ts-interface-checker", () => {
       "value.size is missing");
     assert.throws(() => ICacheItem.check({value: {}, tag: "baz"}),
       "value.key is missing");
+    assert.throws(() => ICacheItem.check({value: {}, tag: "baz"}), VError);
   });
 
   it("should support unions", () => {


### PR DESCRIPTION
See https://github.com/Microsoft/TypeScript/wiki/Breaking-Changes#extending-built-ins-like-error-array-and-map-may-no-longer-work
Also export error-related types.