### PR TITLE
CheckerT interface added to add type guard support

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,3 +132,54 @@ Following on the example above:
 Square.strictCheck({size: 1, color: [255,255,255], bg: "blue"});    // Fails with value.bg is extraneous
 Square.strictCheck({size: 1, color: [255,255,255,0.5]});            // Fails with ...value.color[3] is extraneous
 ```
+
+## Type guards
+
+Standard `Checker` objects do the type checking logic, but are unable to make the TypeScript
+compiler aware that an object of `unknown` type implements a certain interface.
+
+Basic code:
+```typescript
+const unk: unknown = {size: 1, color: "green"};
+// Type is unknown, so TypeScript will not let you access the members.
+console.log(unk.size); // Error: "Object is of type 'unknown'"
+```
+
+With a `Checker` available:
+```typescript
+import fooTI from "./foo-ti";
+import {createCheckers} from "ts-interface-checker";
+
+const {Square} = createCheckers(fooTI);
+
+const unk: unknown = {size: 1, color: "green"};
+
+if (Square.test(unk)) {
+  // unk does implement Square, but TypeScript is not aware of it.
+  console.log(unk.size); // Error: "Object is of type 'unknown'"
+}
+```
+
+To enable type guard functionality on the existing `test`, and `strictTest` functions, `Checker`
+objects should be cast to `CheckerT<>` using the appropriate type.
+
+Using `CheckerT<>`:
+```typescript
+import {Square} from "./foo";
+import fooTI from "./foo-ti";
+import {createCheckers, CheckerT} from "ts-interface-checker";
+
+const {Square} = createCheckers(fooTI) as {Square: CheckerT<Square>};
+
+const unk: unknown = {size: 1, color: "green"};
+
+if (Square.test(unk)) {
+  // TypeScript is now aware that unk implements Square, and allows member access.
+  console.log(unk.size);
+}
+```
+
+## Type assertions
+
+`CheckerT<>` will eventually support type assertions using the `check` and `strictCheck` functions,
+however, this feature is not yet fully working in TypeScript.

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -77,14 +77,6 @@ export class Checker {
   }
 
   /**
-   * Generic type guard function. Causes TypeScript to narrow the type of the value to T if it
-   * passes test().
-   */
-  public typeGuard<T>(value: any): value is T {
-    return this.test(value);
-  }
-
-  /**
    * Returns an error object describing the errors if the given value does not satisfy this
    * Checker's type, or null if it does.
    */
@@ -105,14 +97,6 @@ export class Checker {
    */
   public strictTest(value: any): boolean {
     return this.checkerStrict(value, new NoopContext());
-  }
-
-  /**
-   * Generic type guard function. Causes TypeScript to narrow the type of the value to T if it
-   * passes strictTest().
-   */
-  public strictTypeGuard<T>(value: any): value is T {
-    return this.strictTest(value);
   }
 
   /**
@@ -206,4 +190,28 @@ export class Checker {
     if (!(ttype instanceof TFunc)) { throw new Error(`Property ${methodName} is not a method`); }
     return ttype;
   }
+}
+
+/**
+ * Typed checker interface. Adds type guard functionality to a normal `Checker`.
+ * 
+ * To use, cast a `Checker` to a `CheckerT<>` using the appropriate type.
+ * 
+ * eg.
+ *   import { MyInterface } from './my-interface';
+ *   import MyInterfaceTi from './my-interface-ti';
+ * 
+ *   const checkers = createCheckers(MyInterfaceTi) as {
+ *     MyInterface: CheckerT<MyInterface>
+ *   };
+ * 
+ * TODO:
+ * - Enable `check()` and `strictCheck()` type assertion definitions once the functionality
+ *   is correctly working in TypeScript. (https://github.com/microsoft/TypeScript/issues/36931)
+ */
+export interface CheckerT<T> extends Checker {
+  //check(value: any): asserts value is T;
+  test(value: any): value is T;
+  //strictCheck(value: any): asserts value is T;
+  strictTest(value: any): value is T;
 }

--- a/test/test_checker.ts
+++ b/test/test_checker.ts
@@ -1,5 +1,5 @@
 import {assert} from "chai";
-import {createCheckers, VError} from "../lib/index";
+import {createCheckers, CheckerT, VError} from "../lib/index";
 import * as t from "../lib/types";
 import greetTI from "./fixtures/greet-ti";
 import sample from "./fixtures/sample-ti";
@@ -48,25 +48,20 @@ describe("ts-interface-checker", () => {
   });
 
   it("should support quick tests", () => {
-    const {ICacheItem} = createCheckers({ICacheItem: sample.ICacheItem});
-    assert.isTrue(ICacheItem.test({key: "foo", value: {}, size: 17, tag: "baz"}));
-    assert.isFalse(ICacheItem.test({key: "foo", value: {}, size: "text", tag: "baz"})),
-    assert.isTrue(ICacheItem.strictTest({key: "foo", value: {}, size: 17, tag: "baz"}));
-    assert.isFalse(ICacheItem.strictTest({key: "foo", value: {}, size: "text", tag: "baz"})),
-    assert.isFalse(ICacheItem.strictTest({key: "foo", value: {}, size: 17, tag: "baz", extra: "baz"}));
-    assert.isTrue(ICacheItem.typeGuard<ICacheItemInterface>({key: "foo", value: {}, size: 17, tag: "baz"}));
-    assert.isFalse(ICacheItem.typeGuard<ICacheItemInterface>({key: "foo", value: {}, size: "text", tag: "baz"}));
+    const {ICacheItem} = createCheckers({ICacheItem: sample.ICacheItem}) as { ICacheItem: CheckerT<ICacheItemInterface> };
     const unk: unknown = {key: "foo", value: {}, size: 17, tag: "baz"};
-    if (ICacheItem.typeGuard<ICacheItemInterface>(unk)) {
+    assert.isTrue(ICacheItem.test({key: "foo", value: {}, size: 17, tag: "baz"}));
+    assert.isFalse(ICacheItem.test({key: "foo", value: {}, size: "text", tag: "baz"}));
+    if (ICacheItem.test(unk)) {
       assert.equal(unk.key, "foo");
       assert.deepEqual(unk.value, {});
       assert.equal(unk.size, 17);
       assert.equal(unk.tag, "baz");
     }
-    assert.isTrue(ICacheItem.strictTypeGuard<ICacheItemInterface>({key: "foo", value: {}, size: 17, tag: "baz"}));
-    assert.isFalse(ICacheItem.strictTypeGuard<ICacheItemInterface>({key: "foo", value: {}, size: "text", tag: "baz"}));
-    assert.isFalse(ICacheItem.strictTypeGuard<ICacheItemInterface>({key: "foo", value: {}, size: 17, tag: "baz", extra: "baz"}));
-    if (ICacheItem.strictTypeGuard<ICacheItemInterface>(unk)) {
+    assert.isTrue(ICacheItem.strictTest({key: "foo", value: {}, size: 17, tag: "baz"}));
+    assert.isFalse(ICacheItem.strictTest({key: "foo", value: {}, size: "text", tag: "baz"})),
+    assert.isFalse(ICacheItem.strictTest({key: "foo", value: {}, size: 17, tag: "baz", extra: "baz"}));
+    if (ICacheItem.strictTest(unk)) {
       assert.equal(unk.key, "foo");
       assert.deepEqual(unk.value, {});
       assert.equal(unk.size, 17);


### PR DESCRIPTION
Adds TypeScript type narrowing functionality to `Checker` by wrapping existing `test()` and `strictTest()` functions.

eg.
```
interface MyInterface {
  s: string
}

function myFunc(thing: unknown) {
  if (checkers.MyInterface.test(thing)) {
    // thing does implement MyInterface, but TypeScript will still not let you access the members.
    const s = thing.s; // Error: "Object is of type 'unknown'"
    ...
  }

  if (checkers.MyInterface.typeGuard<MyInterface>(thing)) {
    // TypeScript now knows that thing implements MyInterface, and allows member access.
    const s = thing.s; // No error
    ...
  }
}
```
