### PR TITLE
Multiple nested errors

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -78,8 +78,8 @@ export class Checker {
   }
 
   /**
-   * Returns an error object describing the errors if the given value does not satisfy this
-   * Checker's type, or null if it does.
+   * Returns an array of error objects describing the errors if the given value does not satisfy this
+   * Checker's type, or an empty array if it does.
    */
   public validate(value: any): IErrorDetail[] {
     return this._doValidate(this.checkerPlain, value);
@@ -101,8 +101,8 @@ export class Checker {
   }
 
   /**
-   * Returns an error object describing the errors if the given value does not satisfy this
-   * Checker's type strictly, or null if it does.
+   * Returns an array of error objects describing the errors if the given value does not satisfy this
+   * Checker's type strictly, or an empty array if it does.
    */
   public strictValidate(value: any): IErrorDetail[] {
     return this._doValidate(this.checkerStrict, value);

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -78,7 +78,7 @@ export class Checker {
   }
 
   /**
-   * Returns an error object describing the errors if the given value does not satisfy this
+   * Returns a non-empty array of error objects describing the errors if the given value does not satisfy this
    * Checker's type, or null if it does.
    */
   public validate(value: any): IErrorDetail[]|null {
@@ -101,7 +101,7 @@ export class Checker {
   }
 
   /**
-   * Returns an error object describing the errors if the given value does not satisfy this
+   * Returns a non-empty array of error objects describing the errors if the given value does not satisfy this
    * Checker's type strictly, or null if it does.
    */
   public strictValidate(value: any): IErrorDetail[]|null {

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -81,7 +81,7 @@ export class Checker {
    * Returns an error object describing the errors if the given value does not satisfy this
    * Checker's type, or null if it does.
    */
-  public validate(value: any): IErrorDetail|null {
+  public validate(value: any): IErrorDetail[] {
     return this._doValidate(this.checkerPlain, value);
   }
 
@@ -104,7 +104,7 @@ export class Checker {
    * Returns an error object describing the errors if the given value does not satisfy this
    * Checker's type strictly, or null if it does.
    */
-  public strictValidate(value: any): IErrorDetail|null {
+  public strictValidate(value: any): IErrorDetail[] {
     return this._doValidate(this.checkerStrict, value);
   }
 
@@ -175,14 +175,14 @@ export class Checker {
     }
   }
 
-  private _doValidate(checkerFunc: CheckerFunc, value: any): IErrorDetail|null {
+  private _doValidate(checkerFunc: CheckerFunc, value: any): IErrorDetail[] {
     const noopCtx = new NoopContext();
     if (checkerFunc(value, noopCtx)) {
-      return null;
+      return [];
     }
     const detailCtx = new DetailContext();
     checkerFunc(value, detailCtx);
-    return detailCtx.getErrorDetail(this._path);
+    return detailCtx.getErrorDetails(this._path);
   }
 
   private _getMethod(methodName: string): TFunc {

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -78,10 +78,10 @@ export class Checker {
   }
 
   /**
-   * Returns an array of error objects describing the errors if the given value does not satisfy this
-   * Checker's type, or an empty array if it does.
+   * Returns an error object describing the errors if the given value does not satisfy this
+   * Checker's type, or null if it does.
    */
-  public validate(value: any): IErrorDetail[] {
+  public validate(value: any): IErrorDetail[]|null {
     return this._doValidate(this.checkerPlain, value);
   }
 
@@ -101,10 +101,10 @@ export class Checker {
   }
 
   /**
-   * Returns an array of error objects describing the errors if the given value does not satisfy this
-   * Checker's type strictly, or an empty array if it does.
+   * Returns an error object describing the errors if the given value does not satisfy this
+   * Checker's type strictly, or null if it does.
    */
-  public strictValidate(value: any): IErrorDetail[] {
+  public strictValidate(value: any): IErrorDetail[]|null {
     return this._doValidate(this.checkerStrict, value);
   }
 
@@ -175,10 +175,10 @@ export class Checker {
     }
   }
 
-  private _doValidate(checkerFunc: CheckerFunc, value: any): IErrorDetail[] {
+  private _doValidate(checkerFunc: CheckerFunc, value: any): IErrorDetail[]|null {
     const noopCtx = new NoopContext();
     if (checkerFunc(value, noopCtx)) {
-      return [];
+      return null;
     }
     const detailCtx = new DetailContext();
     checkerFunc(value, detailCtx);

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -305,7 +305,7 @@ export class TIface extends TType {
       if (typeof value !== "object" || value === null) { return ctx.fail(null, "is not an object", 0); }
       for (let i = 0; i < baseCheckers.length; i++) {
         baseCheckers[i](value, ctx.fork());
-        if (!ctx.more()) {
+        if (!ctx.completeFork()) {
           return false;
         }
       }
@@ -315,7 +315,7 @@ export class TIface extends TType {
         if (v === undefined) {
           if (isPropRequired[i]) {
             ctx.fork().fail(name, "is missing", 1);
-            if (!ctx.more()) {
+            if (!ctx.completeFork()) {
               return false;
             }
           }
@@ -323,7 +323,7 @@ export class TIface extends TType {
           const fork = ctx.fork();
           const ok = propCheckers[i](v, fork);
           if (!ok) { fork.fail(name, null, 1); }
-          if (!ctx.more()) {
+          if (!ctx.completeFork()) {
             return false;
           }
         }
@@ -334,7 +334,7 @@ export class TIface extends TType {
           if (!indexTypeChecker(value[prop], fork)) {
             fork.fail(prop, null, 1);
           }
-          if (!ctx.more()) {
+          if (!ctx.completeFork()) {
             return false;
           }
         }
@@ -343,13 +343,13 @@ export class TIface extends TType {
         for (const prop in value) {
           if (!allowedProps.has(prop)) {
             ctx.fork().fail(prop, "is extraneous", 2);
-            if (!ctx.more()) {
+            if (!ctx.completeFork()) {
               return false;
             }
           }
         }
       }
-      return true;
+      return !ctx.failed();
     };
   }
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -199,9 +199,10 @@ export class TIntersection extends TType {
   public getChecker(suite: ITypeSuite, strict: boolean, allowedProps: Set<string> = new Set()): CheckerFunc {
     const itemCheckers = this.ttypes.map((t) => t.getChecker(suite, strict, allowedProps));
     return (value: any, ctx: IContext) => {
-      const ok = itemCheckers.every(checker => checker(value, ctx))
-      if (ok) { return true; }
-      return ctx.fail(null, null, 0);
+      return itemCheckers.every(checker => {
+        checker(value, ctx.fork());
+        return ctx.completeFork();
+      });
     };
   }
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -202,7 +202,7 @@ export class TIntersection extends TType {
       return itemCheckers.every(checker => {
         checker(value, ctx.fork());
         return ctx.completeFork();
-      });
+      }) && !ctx.failed();
     };
   }
 }

--- a/lib/util.ts
+++ b/lib/util.ts
@@ -113,8 +113,7 @@ export class DetailContext implements IContext {
   }
 
   public getError(path: string): VError {
-    const fullMessage = this.getErrorDetails(path)
-        .flatMap(errorLines)
+    const fullMessage = flatten(this.getErrorDetails(path).map(errorLines))
         .join("\n");
     return new VError(path, fullMessage);
   }
@@ -138,7 +137,7 @@ export class DetailContext implements IContext {
       }
     }
     if (this._forks.length) {
-      const forkErrors = this._forks.flatMap(fork => fork.getErrorDetails(path));
+      const forkErrors = flatten(this._forks.map(fork => fork.getErrorDetails(path)));
       if (detail) {
         detail.nested = forkErrors;
       } else {
@@ -186,7 +185,7 @@ class DetailUnionResolver implements IUnionResolver {
 const errorLines = (error: IErrorDetail): string[] => {
   const rootMessage = `${error.path} ${error.message}`;
   const nestedErrors = error.nested || [];
-  const nestedLines = nestedErrors.flatMap(errorLines);
+  const nestedLines = flatten(nestedErrors.map(errorLines));
   if (nestedErrors.length == 1) {
     const [first, ...rest] = nestedLines;
     return [
@@ -199,4 +198,8 @@ const errorLines = (error: IErrorDetail): string[] => {
       ...nestedLines.map(line => "    " + line)
     ];
   }
+}
+
+function flatten<T>(arr: T[][]): T[] {
+  return ([] as T[]).concat(...arr);
 }

--- a/lib/util.ts
+++ b/lib/util.ts
@@ -67,7 +67,10 @@ export class NoopContext implements IContext, IUnionResolver {
   }
 
   public unionResolver(): IUnionResolver { return this; }
-  public createContext(): IContext { return this; }
+  public createContext(): IContext {
+    this._failed = false;
+    return this;
+  }
   public resolveUnion(ur: IUnionResolver): void { /* noop */ }
 }
 

--- a/lib/util.ts
+++ b/lib/util.ts
@@ -54,7 +54,6 @@ export class NoopContext implements IContext, IUnionResolver {
   }
 
   public fork(): IContext {
-    this._failed = false;
     return this;
   }
 

--- a/lib/util.ts
+++ b/lib/util.ts
@@ -19,8 +19,40 @@ export interface IContext {
   unionResolver(): IUnionResolver;
   resolveUnion(ur: IUnionResolver): void;
 
+  /**
+   * Used only in checkers of types that may record multiple
+   * parallel failures for a single object. After calling fork(), a checker must:
+   *
+   *
+   * - Use the returned forked context instead of the original context for (potential) failures,
+   *    whether it's in a deeper checker or when calling fail().
+   * - After using the fork to check one 'thing' (e.g. a property or a base class), write:
+   *
+   *       if (!ctx.completeFork()) {
+   *         return false;
+   *       }
+   *
+   *    Always call completeFork(), regardless of whether there was a failure.
+   *    Do this instead of returning directly after a failure as is done with non-forked type checkers.
+   * - Once you're done checking, `return !ctx.failed()`
+   *    to check whether any failures were gathered along the way in forks.
+   */
   fork(): IContext;
+
+  /**
+   * Must always be called after a call to fork() on the same context.
+   *
+   * Indicates that the checker is done with the current fork and any subsequent
+   * checks on the current object will be done on a new fork.
+   *
+   * Returns true if the checker should keep checking the current object,
+   * or false if enough failures have been noted and the checker should return now.
+   */
   completeFork(): boolean;
+
+  /**
+   * Returns true if any failures were recorded in this context.
+   */
   failed(): boolean;
 }
 
@@ -81,8 +113,22 @@ export class DetailContext implements IContext {
   private _propNames: Array<string|number|null> = [];
   private _messages: Array<string|null> = [];
 
+  /** Contexts created by fork() which have completed and contain failures */
   private _failedForks: Array<DetailContext> = [];
-  private _maxForks = 3;
+
+  /**
+   * Maximum number of errors recorded at one level for an object,
+   * i.e. the maximum length of Checker.validate() or IErrorDetail.nested.
+   */
+  // If _failedForks has this length then completeFork() should return false
+  // so that the checker stops making more forks.
+  public static maxForks = 3;
+
+  /**
+   * Contains the context returned by fork() which should be checked until
+   * completeFork() is called.
+   * Will be reused for the next fork() if there are no failures.
+   */
   private _currentFork: DetailContext|null = null;
 
   // Score is used to choose the best union member whose DetailContext to use for reporting.
@@ -123,27 +169,33 @@ export class DetailContext implements IContext {
     let detail: IErrorDetail|null = null;
     let nested: IErrorDetail;
     const details: IErrorDetail[] = [];
+
+    // As checkers call fail() and return to their parent checkers,
+    // the deepest failures are recorded first.
+    // Go through failures in reverse to start from the root type
     for (let i = this._propNames.length - 1; i >= 0; i--) {
       const p = this._propNames[i];
       path += (typeof p === "number") ? `[${p}]` : (p ? `.${p}` : "");
       const message = this._messages[i];
-      if (message) {
-        nested = {path, message}
-        if (detail) {
-          detail.nested = [nested]
-        } else {
-          details.push(nested);
-        }
-        detail = nested
+      if (!message) {
+        continue;
       }
-    }
-    if (this._failedForks.length) {
-      const forkErrors = flatten(this._failedForks.map(fork => fork.getErrorDetails(path)));
+
+      nested = {path, message}
       if (detail) {
-        detail.nested = forkErrors;
+        detail.nested = [nested]
       } else {
-        details.push(...forkErrors);
+        // This is the root failure, so it will be returned
+        details.push(nested);
       }
+      detail = nested
+    }
+
+    const forkErrors = flatten(this._failedForks.map(fork => fork.getErrorDetails(path)));
+    if (detail && forkErrors.length) {  // don't put an empty array in detail.nested
+      detail.nested = forkErrors;
+    } else {
+      details.push(...forkErrors);
     }
 
     return details;
@@ -159,16 +211,23 @@ export class DetailContext implements IContext {
   public completeFork(): boolean {
     const fork = this._currentFork!;
     if (fork._failed()) {
-      // To preserve old behaviour, use the score of the first failure
-      // Might want to revise this
-      if (!this._failedForks.length) {
-        this._score = fork._score;
-      }
       this._failedForks.push(fork);
       this._currentFork = null;
+
+      // To preserve old behaviour, use the score of the first failure
+      // Might want to revise this
+      if (this._failedForks.length === 1) {
+        this._score = fork._score;
+      }
+
     }
-    return this._failedForks.length < this._maxForks;
+    return this._failedForks.length < DetailContext.maxForks;
   }
+
+  // failed() is the public interface,
+  // it gets monkeypatched to ensure correct usage in checkers.
+  // _failed() may be called internally
+  // in ways which would fail the monkeypatched assertions.
 
   public failed(): boolean {
     return this._failed();
@@ -188,17 +247,30 @@ class DetailUnionResolver implements IUnionResolver {
   }
 }
 
+/**
+ * Returns lines of a message describing `error`.
+ * The lines should be newline separated in the final message.
+ * Only returns multiple lines if `error` or a descendent
+ * has multiple errors in its `.nested` array.
+ * Simple paths of nested errors anywhere in the tree
+ * are collapsed into a single line until a branch is reached.
+ */
 const errorLines = (error: IErrorDetail): string[] => {
   const rootMessage = `${error.path} ${error.message}`;
   const nestedErrors = error.nested || [];
   const nestedLines = flatten(nestedErrors.map(errorLines));
   if (nestedErrors.length == 1) {
+    // Single nested errors are collapsed into the first line,
+    // but they may have branches deeper down leading to more lines
+    // which are already indented
     const [first, ...rest] = nestedLines;
     return [
       `${rootMessage}; ${first}`,
       ...rest,
     ];
   } else {
+    // Indent messages from nested errors
+    // or just return [rootMessage] if there are no nested errors
     return [
       rootMessage,
       ...nestedLines.map(line => "    " + line)
@@ -206,6 +278,7 @@ const errorLines = (error: IErrorDetail): string[] => {
   }
 }
 
+/** Shallow flatten a 2D array into a 1D array */
 function flatten<T>(arr: T[][]): T[] {
   return ([] as T[]).concat(...arr);
 }

--- a/lib/util.ts
+++ b/lib/util.ts
@@ -185,20 +185,18 @@ class DetailUnionResolver implements IUnionResolver {
 
 const errorLines = (error: IErrorDetail): string[] => {
   const rootMessage = `${error.path} ${error.message}`;
-  if (error.nested?.length) {
-    if (error.nested.length > 1) {
-      return [
-        rootMessage,
-        ...error.nested.flatMap(errorLines).map(line => "    " + line)
-      ];
-    } else {
-      const [first, ...rest] = errorLines(error.nested[0]);
-      return [
-        `${rootMessage}; ${first}`,
-        ...rest,
-      ];
-    }
+  const nestedErrors = error.nested || [];
+  const nestedLines = nestedErrors.flatMap(errorLines);
+  if (nestedErrors.length == 1) {
+    const [first, ...rest] = nestedLines;
+    return [
+      `${rootMessage}; ${first}`,
+      ...rest,
+    ];
   } else {
-    return [rootMessage];
+    return [
+      rootMessage,
+      ...nestedLines.map(line => "    " + line)
+    ];
   }
-} 
+}

--- a/lib/util.ts
+++ b/lib/util.ts
@@ -250,7 +250,7 @@ class DetailUnionResolver implements IUnionResolver {
 /**
  * Returns lines of a message describing `error`.
  * The lines should be newline separated in the final message.
- * Only returns multiple lines if `error` or a descendent
+ * Only returns multiple lines if `error` or a descendant
  * has multiple errors in its `.nested` array.
  * Simple paths of nested errors anywhere in the tree
  * are collapsed into a single line until a branch is reached.

--- a/test/monkeypatch.ts
+++ b/test/monkeypatch.ts
@@ -1,0 +1,114 @@
+import {assert} from "chai";
+import {DetailContext, NoopContext} from "../lib/util";
+
+/**
+ * Replace the method called `name` of `cls`
+ * with a patched method that calls `replacement`.
+ *
+ * `replacement` gets two arguments:
+ * - `instance` is the instance of `cls` whose method is being called, i.e. `this`.
+ * - `original` is the original method that was patched, with all arguments bound.
+ *      You must call it with no arguments and return its result.
+ *
+ * The same method can be patched multiple times and each successive patch
+ * will call the previous patch as expected.
+ */
+const patchMethod = (
+    cls: any,
+    name: string,
+    replacement: (instance: any, original: Function) => void
+): void => {
+    const originalMethod: Function = cls.prototype[name];
+    cls.prototype[name] = function () {
+        const original = originalMethod.bind(this, ...Array.from(arguments));
+        return replacement(this, original);
+    }
+};
+
+/**
+ * In fork() and in failed(),
+ * assert that the user shouldn't have returned due to previous failure(s).
+ */
+{
+    const message = "This context has failed too much, " +
+        "you should have returned already after a call to fail() or completeFork()."
+    const notFailedNoop = (ctx: any, original: Function) => {
+        assert.isFalse(ctx._failed, message);
+        return original();
+    };
+    patchMethod(NoopContext, "fork", notFailedNoop);
+    patchMethod(NoopContext, "failed", notFailedNoop);
+
+    const notFailedDetail = (ctx: any, original: Function) => {
+        assert.isEmpty(ctx._propNames, message);
+        assert.isEmpty(ctx._messages, message);
+        assert.isBelow(ctx._failedForks.length, ctx._maxForks, message);
+        return original();
+    };
+    patchMethod(DetailContext, "fork", notFailedDetail);
+    patchMethod(DetailContext, "failed", notFailedDetail);
+}
+
+// The remaining assertions only apply to DetailContext
+// We can't assert much about NoopContext because it returns itself
+// instead of creating new contexts when forked
+
+/**
+ * Assert that fork() and completeFork() are called in pairs,
+ * and that the forked context is used between instead of the original.
+ */
+{
+    patchMethod(DetailContext, "fork", (ctx, original) => {
+        assert.isNotTrue(
+            ctx._activeFork,
+            "There's already an active fork, did you use the original context instead of the fork? " +
+            "Or did you miss a call to completeFork()?"
+        );
+        ctx._activeFork = true;
+        return original();
+    });
+
+    patchMethod(DetailContext, "completeFork", (ctx, original) => {
+        assert.isTrue(
+            ctx._activeFork,
+            "There's no active fork, did you miss a call to fork()?"
+        );
+        ctx._activeFork = false;
+        return original();
+    });
+
+    patchMethod(DetailContext, "fail", (ctx, original) => {
+        assert.isNotTrue(
+            ctx._activeFork,
+            "There's still an active fork, did you use the original context instead of the fork? " +
+            "Or did you miss a call to completeFork()?"
+        );
+        return original();
+    });
+}
+
+/** See error message in assertion */
+{
+    patchMethod(DetailContext, "completeFork", (ctx, original) => {
+        const result = original();
+        ctx._shouldCallFailed = result;
+        return result;
+    });
+
+    patchMethod(DetailContext, "failed", (ctx, original) => {
+        ctx._shouldCallFailed = false;
+        return original();
+    });
+
+    patchMethod(DetailContext, "fail", (ctx, original) => {
+        assert.isNotTrue(
+            ctx._shouldCallFailed,
+            "Called ctx.fail() after ctx.completeFork() returned true " +
+            "without an intervening call to ctx.failed(). " +
+            "Once a checker starts forking its context, " +
+            "it mustn't call fail() directly on that context or pass it to other checkers, " +
+            "and it must return !ctx.failed() at the end."
+        );
+        return original();
+    });
+}

--- a/test/monkeypatch.ts
+++ b/test/monkeypatch.ts
@@ -14,15 +14,15 @@ import {DetailContext, NoopContext} from "../lib/util";
  * will call the previous patch as expected.
  */
 const patchMethod = (
-    cls: any,
-    name: string,
-    replacement: (instance: any, original: Function) => void
+  cls: any,
+  name: string,
+  replacement: (instance: any, original: Function) => void
 ): void => {
-    const originalMethod: Function = cls.prototype[name];
-    cls.prototype[name] = function () {
-        const original = originalMethod.bind(this, ...Array.from(arguments));
-        return replacement(this, original);
-    }
+  const originalMethod: Function = cls.prototype[name];
+  cls.prototype[name] = function () {
+    const original = originalMethod.bind(this, ...Array.from(arguments));
+    return replacement(this, original);
+  }
 };
 
 /**
@@ -30,23 +30,23 @@ const patchMethod = (
  * assert that the user shouldn't have returned due to previous failure(s).
  */
 {
-    const message = "This context has failed too much, " +
-        "you should have returned already after a call to fail() or completeFork()."
-    const notFailedNoop = (ctx: any, original: Function) => {
-        assert.isFalse(ctx._failed, message);
-        return original();
-    };
-    patchMethod(NoopContext, "fork", notFailedNoop);
-    patchMethod(NoopContext, "failed", notFailedNoop);
+  const message = "This context has failed too much, " +
+    "you should have returned already after a call to fail() or completeFork()."
+  const notFailedNoop = (ctx: any, original: Function) => {
+    assert.isFalse(ctx._failed, message);
+    return original();
+  };
+  patchMethod(NoopContext, "fork", notFailedNoop);
+  patchMethod(NoopContext, "failed", notFailedNoop);
 
-    const notFailedDetail = (ctx: any, original: Function) => {
-        assert.isEmpty(ctx._propNames, message);
-        assert.isEmpty(ctx._messages, message);
-        assert.isBelow(ctx._failedForks.length, DetailContext.maxForks, message);
-        return original();
-    };
-    patchMethod(DetailContext, "fork", notFailedDetail);
-    patchMethod(DetailContext, "failed", notFailedDetail);
+  const notFailedDetail = (ctx: any, original: Function) => {
+    assert.isEmpty(ctx._propNames, message);
+    assert.isEmpty(ctx._messages, message);
+    assert.isBelow(ctx._failedForks.length, DetailContext.maxForks, message);
+    return original();
+  };
+  patchMethod(DetailContext, "fork", notFailedDetail);
+  patchMethod(DetailContext, "failed", notFailedDetail);
 }
 
 // The remaining assertions only apply to DetailContext
@@ -58,57 +58,57 @@ const patchMethod = (
  * and that the forked context is used between instead of the original.
  */
 {
-    patchMethod(DetailContext, "fork", (ctx, original) => {
-        assert.isNotTrue(
-            ctx._activeFork,
-            "There's already an active fork, did you use the original context instead of the fork? " +
-            "Or did you miss a call to completeFork()?"
-        );
-        ctx._activeFork = true;
-        return original();
-    });
+  patchMethod(DetailContext, "fork", (ctx, original) => {
+    assert.isNotTrue(
+      ctx._activeFork,
+      "There's already an active fork, did you use the original context instead of the fork? " +
+      "Or did you miss a call to completeFork()?"
+    );
+    ctx._activeFork = true;
+    return original();
+  });
 
-    patchMethod(DetailContext, "completeFork", (ctx, original) => {
-        assert.isTrue(
-            ctx._activeFork,
-            "There's no active fork, did you miss a call to fork()?"
-        );
-        ctx._activeFork = false;
-        return original();
-    });
+  patchMethod(DetailContext, "completeFork", (ctx, original) => {
+    assert.isTrue(
+      ctx._activeFork,
+      "There's no active fork, did you miss a call to fork()?"
+    );
+    ctx._activeFork = false;
+    return original();
+  });
 
-    patchMethod(DetailContext, "fail", (ctx, original) => {
-        assert.isNotTrue(
-            ctx._activeFork,
-            "There's still an active fork, did you use the original context instead of the fork? " +
-            "Or did you miss a call to completeFork()?"
-        );
-        return original();
-    });
+  patchMethod(DetailContext, "fail", (ctx, original) => {
+    assert.isNotTrue(
+      ctx._activeFork,
+      "There's still an active fork, did you use the original context instead of the fork? " +
+      "Or did you miss a call to completeFork()?"
+    );
+    return original();
+  });
 }
 
 /** See error message in assertion */
 {
-    patchMethod(DetailContext, "completeFork", (ctx, original) => {
-        const result = original();
-        ctx._shouldCallFailed = result;
-        return result;
-    });
+  patchMethod(DetailContext, "completeFork", (ctx, original) => {
+    const result = original();
+    ctx._shouldCallFailed = result;
+    return result;
+  });
 
-    patchMethod(DetailContext, "failed", (ctx, original) => {
-        ctx._shouldCallFailed = false;
-        return original();
-    });
+  patchMethod(DetailContext, "failed", (ctx, original) => {
+    ctx._shouldCallFailed = false;
+    return original();
+  });
 
-    patchMethod(DetailContext, "fail", (ctx, original) => {
-        assert.isNotTrue(
-            ctx._shouldCallFailed,
-            "Called ctx.fail() after ctx.completeFork() returned true " +
-            "without an intervening call to ctx.failed(). " +
-            "Once a checker starts forking its context, " +
-            "it mustn't call fail() directly on that context or pass it to other checkers, " +
-            "and it must return !ctx.failed() at the end."
-        );
-        return original();
-    });
+  patchMethod(DetailContext, "fail", (ctx, original) => {
+    assert.isNotTrue(
+      ctx._shouldCallFailed,
+      "Called ctx.fail() after ctx.completeFork() returned true " +
+      "without an intervening call to ctx.failed(). " +
+      "Once a checker starts forking its context, " +
+      "it mustn't call fail() directly on that context or pass it to other checkers, " +
+      "and it must return !ctx.failed() at the end."
+    );
+    return original();
+  });
 }

--- a/test/monkeypatch.ts
+++ b/test/monkeypatch.ts
@@ -119,11 +119,11 @@ const patchMethod = (
 {
   /** Ensure there are no empty strings or arrays */
   const checkErrorDetails = (errors: IErrorDetail[]) => {
+    assert.isNotEmpty(errors, "There shouldn't be any empty arrays of errors anywhere");
     errors.forEach(error => {
       assert.isNotEmpty(error.path);
       assert.isNotEmpty(error.message);
       if (error.nested) {
-        assert.isNotEmpty(error.nested);
         checkErrorDetails(error.nested);
       }
     })
@@ -131,12 +131,8 @@ const patchMethod = (
 
   patchMethod(DetailContext, "getErrorDetails", (ctx, original) => {
     const result = original();
+    assert.isTrue(ctx._failed(), "getErrorDetails() should only be called after a NoopContext failed");
     checkErrorDetails(result);
-    assert.equal(
-      result.length > 0,
-      ctx._failed(),
-      "getErrorDetails() should return a non-empty array if and only if the context failed."
-    );
     if (ctx._messages.length) {
       assert.equal(
         result.length,

--- a/test/monkeypatch.ts
+++ b/test/monkeypatch.ts
@@ -42,7 +42,7 @@ const patchMethod = (
     const notFailedDetail = (ctx: any, original: Function) => {
         assert.isEmpty(ctx._propNames, message);
         assert.isEmpty(ctx._messages, message);
-        assert.isBelow(ctx._failedForks.length, ctx._maxForks, message);
+        assert.isBelow(ctx._failedForks.length, DetailContext.maxForks, message);
         return original();
     };
     patchMethod(DetailContext, "fork", notFailedDetail);

--- a/test/monkeypatch.ts
+++ b/test/monkeypatch.ts
@@ -135,7 +135,7 @@ const patchMethod = (
     assert.equal(
       result.length > 0,
       ctx._failed(),
-      "getErrorDetails() should return an empty array if and only if the context failed."
+      "getErrorDetails() should return a non-empty array if and only if the context failed."
     );
     if (ctx._messages.length) {
       assert.equal(

--- a/test/test_checker.ts
+++ b/test/test_checker.ts
@@ -9,7 +9,7 @@ import enumUnionTI from "./fixtures/enum-union-ti";
 import intersectionTI from "./fixtures/intersection-ti";
 import indexSignaturesTI from "./fixtures/index-signatures-ti";
 import recursiveTI from "./fixtures/recursive-ti";
-import "./monkeypatch";
+import {applyPatches, removePatches} from "./monkeypatch";
 
 function noop() { /* noop */ }
 
@@ -20,7 +20,15 @@ interface ICacheItemInterface {
   tag?: string
 }
 
-describe("ts-interface-checker", () => {
+describe("ts-interface-checker", suite);
+
+describe('ts-interface-checker-with-asserts', () => {
+  before(() => applyPatches());
+  after(() => removePatches());
+  suite();
+});
+
+function suite() {
   it("should validate data", () => {
     const {ICacheItem} = createCheckers({ICacheItem: sample.ICacheItem});
 
@@ -727,7 +735,8 @@ describe("ts-interface-checker", () => {
       {"path": "value.c", "message": "is missing"},
     );
   });
-});
+};
+
 
 /**
  * Removes common leading indentation from a multiline string

--- a/test/test_checker.ts
+++ b/test/test_checker.ts
@@ -576,12 +576,12 @@ describe("ts-interface-checker", () => {
       Foo: t.iface([], {x: "number", y: "number"}),
     });
 
-    assert.isEmpty(Shape.validate({kind: "square", size: 17}));
-    assert.isEmpty(Shape.validate({kind: "rectangle", width: 17, height: 4}));
-    assert.isEmpty(Shape.validate({kind: "circle", radius: 0.5}));
+    assert.isNull(Shape.validate({kind: "square", size: 17}));
+    assert.isNull(Shape.validate({kind: "rectangle", width: 17, height: 4}));
+    assert.isNull(Shape.validate({kind: "circle", radius: 0.5}));
 
     // Extraneous property.
-    assert.isEmpty(Shape.validate({kind: "square", size: 17, depth: 5}));
+    assert.isNull(Shape.validate({kind: "square", size: 17, depth: 5}));
     assert.deepEqual(Shape.strictValidate({kind: "square", size: 17, depth: 5}), [{
       path: "value", message: "is none of Square, Rectangle, Circle",
       nested: [{
@@ -608,8 +608,8 @@ describe("ts-interface-checker", () => {
       }
     );
 
-    assert.isEmpty(Type.validate({a: 12}));
-    assert.isEmpty(Type.validate({a: {foo: 12}}));
+    assert.isNull(Type.validate({a: 12}));
+    assert.isNull(Type.validate({a: {foo: 12}}));
     assertCheckerErrors(
       Type,
       {a: "x"},

--- a/test/test_checker.ts
+++ b/test/test_checker.ts
@@ -228,6 +228,7 @@ describe("ts-interface-checker", () => {
   it("should handle discriminated unions", () => {
     const {Shape} = createCheckers(shapes);
     Shape.check({kind: "square", size: 17});
+    Shape.strictCheck({kind: "square", size: 17});
     Shape.check({kind: "rectangle", width: 17, height: 4});
     Shape.check({kind: "circle", radius: 0.5});
 
@@ -564,6 +565,11 @@ describe("ts-interface-checker", () => {
       Type: t.union(t.iface([], {a: "Foo"}),
                     t.iface([], {a: "number"})),
     });
+    const {Bar} = createCheckers({
+      Bar: t.iface([], {spam: "Spam", other: "number"}),
+      Spam: t.iface([], {foo: "Foo", z: "number"}),
+      Foo: t.iface([], {x: "number", y: "number"}),
+    });
 
     assert.isNull(Shape.validate({kind: "square", size: 17}));
     assert.isNull(Shape.validate({kind: "rectangle", width: 17, height: 4}));
@@ -608,6 +614,20 @@ describe("ts-interface-checker", () => {
           path: "value.a.foo", message: "is not a number",
         }],
       }],
+    });
+
+    assert.deepEqual(Bar.validate({spam: {foo: {}}}), {
+      path: "value.spam", message: "is not a Spam",
+      nested: [
+        {
+          path: "value.spam.foo", message: "is not a Foo",
+          nested: [
+            {
+              path: "value.spam.foo.x", message: "is missing",
+            }
+          ],
+        }
+      ],
     });
   });
 });

--- a/test/test_checker.ts
+++ b/test/test_checker.ts
@@ -629,5 +629,30 @@ describe("ts-interface-checker", () => {
         {path: "value.spam.z", message: "is missing"},
       ],
     });
+
+    const {C} = createCheckers({
+      A: t.iface([], {a: "number"}),
+      B: t.iface([], {b: "number"}),
+      AB: t.intersection("A", "B"),
+      C: t.iface([], {ab: "AB"}),
+    });
+
+    assert.deepEqual(C.validate({ab: {}}), {
+      "path": "value.ab", "message": "is not a AB",
+      "nested": [
+        {
+          "path": "value.ab", "message": "is not a A",
+          "nested": [
+            {"path": "value.ab.a", "message": "is missing"}
+          ],
+        },
+        {
+          "path": "value.ab", "message": "is not a B",
+          "nested": [
+            {"path": "value.ab.b", "message": "is missing"}
+          ],
+        }
+      ],
+    });
   });
 });

--- a/test/test_checker.ts
+++ b/test/test_checker.ts
@@ -622,11 +622,11 @@ describe("ts-interface-checker", () => {
         {
           path: "value.spam.foo", message: "is not a Foo",
           nested: [
-            {
-              path: "value.spam.foo.x", message: "is missing",
-            }
+            {path: "value.spam.foo.x", message: "is missing"},
+            {path: "value.spam.foo.y", message: "is missing"},
           ],
-        }
+        },
+        {path: "value.spam.z", message: "is missing"},
       ],
     });
   });

--- a/test/test_checker.ts
+++ b/test/test_checker.ts
@@ -9,6 +9,7 @@ import enumUnionTI from "./fixtures/enum-union-ti";
 import intersectionTI from "./fixtures/intersection-ti";
 import indexSignaturesTI from "./fixtures/index-signatures-ti";
 import recursiveTI from "./fixtures/recursive-ti";
+import "./monkeypatch";
 
 function noop() { /* noop */ }
 

--- a/test/test_checker.ts
+++ b/test/test_checker.ts
@@ -705,6 +705,9 @@ describe("ts-interface-checker", () => {
 /**
  * Removes common leading indentation from a multiline string
  * Based on https://stackoverflow.com/a/25937397/2482744
+ *
+ * The string should start with a newline so that the indentation
+ * can be calculated from the first non-blank line.
  */
 const dedent = (s: string) => {
   let size = -1;
@@ -719,6 +722,9 @@ const dedent = (s: string) => {
   }).trim();
 }
 
+/**
+ * Test error message from check() and error details from validate() at the same time.
+ */
 const assertCheckerErrors = (checker: Checker, value: any, message: string, ...errors: IErrorDetail[]): void => {
   assert.deepEqual(checker.validate(value), errors);
   assert.throws(() => checker.check(value), dedent(message));

--- a/test/test_checker.ts
+++ b/test/test_checker.ts
@@ -700,6 +700,33 @@ describe("ts-interface-checker", () => {
       }
     );
   });
+
+  it("should not return too many errors", () => {
+    const {Foo} = createCheckers({
+      Foo: t.iface([], {
+        a: "number",
+        b: "number",
+        c: "number",
+        d: "number",
+        e: "number",
+        f: "number",
+      }),
+    });
+
+    assertCheckerErrors(
+      Foo,
+      {},
+      // Only DetailContext.maxForks (3) errors
+      `
+      value.a is missing
+      value.b is missing
+      value.c is missing
+      `,
+      {"path": "value.a", "message": "is missing"},
+      {"path": "value.b", "message": "is missing"},
+      {"path": "value.c", "message": "is missing"},
+    );
+  });
 });
 
 /**

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
     "baseUrl": ".",
     "outDir": "dist",
     "declaration": true,
-    "lib": ["es2015"]
+    "lib": ["es2019"]
   },
   "include": [
     "lib/*.ts"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
     "baseUrl": ".",
     "outDir": "dist",
     "declaration": true,
-    "lib": ["es2019"]
+    "lib": ["es2015"]
   },
   "include": [
     "lib/*.ts"


### PR DESCRIPTION
This is an attempt to solve #3 and #16, allowing the result of `validate` to have multiple errors in the same `nested` array so that users can solve several problems in their input data at once.

At the moment this is a proof of concept, there's still quite a bit of work to do and decisions to be made, including whether to go forward with this at all.

Most types don't need to be able to report multiple errors so they haven't changed. Some types we could consider adding this to but I'm reluctant about:

- TArray: if you get one item wrong, several others are probably wrong for the same reason.
- TTuple and TParamList: if you forget an item before the end or get the order wrong, this will cause several errors with the same fix.
- TUnion: it might be nice to show why a few candidates failed instead of just one best guess, but this is questionable.

So for now it's just TIface and TIntersection. TIface is a good example to show how this works.

First, this line is unchanged:

```ts
if (typeof value !== "object" || value === null) { return ctx.fail(null, "is not an object", 0); }
```

If it's not an object, there's nothing else to report, so we call `ctx.fail` directly and then return early. But from here on, `fail` must no longer be called directly on `ctx`, at least until this checker returns. Failures will instead be stored in *forks*. These could be renamed to branches, children, subcontexts, etc. They should be used as follows:

- Get a forked context with `ctx.fork()`
- Use the fork rather than `ctx` for (potential) failures, whether it's in a deeper checker as in `propCheckers[i](v, fork)` or directly as in `fork.fail(name, null, 1)`.
- After using the fork to check one 'thing' (e.g. a property or a base class), write:

```ts
          if (!ctx.completeFork()) {
            return false;
          }
```

- The main context might make use of the information that you're done with the latest fork.
- It then returns true if there's 'room' for more errors and you should continue checking, or false if you should just return now.
- Once you're done checking, `return !ctx.failed()` to check whether any failures were gathered along the way without triggering an early return.

The NoopContext still does very little, only storing a boolean and returning itself from `fork()`. But the extra operations have some inevitable overhead. I haven't done proper calculations yet but at a glance the benchmark (great thing to have!) seems to run something like 10-15% slower.

The DetailContext keeps forks that have failures in them. The way it does this right now is not very clever and will probably be optimised. The number of failed forks it keeps is limited (right now to 3, but that will be made configurable) so that users don't get flooded with errors. Once it reaches that limit, `ctx.completeFork()` returns false to indicate you should exit. But since you can now have a whole tree of contexts, the total number of forks and errors is unlimited.

Some things that still need addressing:

- Formatting a nice hierarchical multiline VError message when necessary
- A proper API - I have many thoughts on this topic
- The issue I mentioned in https://github.com/gristlabs/ts-interface-checker/pull/4#issuecomment-808807995

What are your thoughts so far?