### PR TITLE
Add name to arrays for more explicit error messages

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -103,7 +103,13 @@ export class TLiteral extends TType {
  */
 export function array(typeSpec: TypeSpec): TArray { return new TArray(parseSpec(typeSpec)); }
 export class TArray extends TType {
-  constructor(public ttype: TType) { super(); }
+  public name?: string;
+  constructor(public ttype: TType) {
+    super();
+    if (ttype instanceof TName || ttype instanceof TLiteral || ttype instanceof TArray) {
+      this.name = ttype.name ? `${ttype.name}[]` : undefined;
+    }
+  }
 
   public getChecker(suite: ITypeSuite, strict: boolean): CheckerFunc {
     const itemChecker = this.ttype.getChecker(suite, strict);
@@ -158,7 +164,7 @@ export class TUnion extends TType {
   private _failMsg: string;
   constructor(public ttypes: TType[]) {
     super();
-    const names = ttypes.map((t) => t instanceof TName || t instanceof TLiteral ? t.name : null)
+    const names = ttypes.map((t) => t instanceof TName || t instanceof TLiteral || t instanceof TArray ? t.name : null)
       .filter((n) => n);
     const otherTypes: number = ttypes.length - names.length;
     if (names.length) {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -106,8 +106,9 @@ export class TArray extends TType {
   public name?: string;
   constructor(public ttype: TType) {
     super();
-    if (ttype instanceof TName || ttype instanceof TLiteral || ttype instanceof TArray) {
-      this.name = ttype.name ? `${ttype.name}[]` : undefined;
+    const elementTypeName = getTypeName(ttype)
+    if (elementTypeName) {
+      this.name = `${elementTypeName}[]`
     }
   }
 
@@ -164,7 +165,7 @@ export class TUnion extends TType {
   private _failMsg: string;
   constructor(public ttypes: TType[]) {
     super();
-    const names = ttypes.map((t) => t instanceof TName || t instanceof TLiteral || t instanceof TArray ? t.name : null)
+    const names = ttypes.map(getTypeName)
       .filter((n) => n);
     const otherTypes: number = ttypes.length - names.length;
     if (names.length) {
@@ -498,4 +499,10 @@ if (typeof Buffer !== "undefined") {
 for (const array of [Int8Array, Uint8Array, Uint8ClampedArray, Int16Array, Uint16Array,
                      Int32Array, Uint32Array, Float32Array, Float64Array, ArrayBuffer]) {
   basicTypes[array.name] = new BasicType((v) => (v instanceof array), `is not a ${array.name}`);
+}
+
+function getTypeName(t: TType): string | undefined {
+  if (t instanceof TName || t instanceof TLiteral || t instanceof TArray) {
+    return t.name
+  }
 }

--- a/test/fixtures/enum-union-ti.ts
+++ b/test/fixtures/enum-union-ti.ts
@@ -30,11 +30,17 @@ export const Circle = t.iface(["Shape"], {
   "radius": "number",
 });
 
+export const MixedArray = t.array(t.union("string", "number", t.array("string")));
+
+export const ArrayUnion = t.union(t.array("string"), t.array("boolean"), t.array("number"), t.array(t.array("string")));
+
 const exportedTypeSuite: t.ITypeSuite = {
   ShapeKind,
   Shape,
   Square,
   Rectangle,
   Circle,
+  MixedArray,
+  ArrayUnion,
 };
 export default exportedTypeSuite;

--- a/test/fixtures/enum-union-ti.ts
+++ b/test/fixtures/enum-union-ti.ts
@@ -34,6 +34,8 @@ export const MixedArray = t.array(t.union("string", "number", t.array("string"))
 
 export const ArrayUnion = t.union(t.array("string"), t.array("boolean"), t.array("number"), t.array(t.array("string")));
 
+export const UnionWithUnnamedArray = t.union(t.array("string"), t.array("number"), t.array(t.union("string", "boolean")));
+
 const exportedTypeSuite: t.ITypeSuite = {
   ShapeKind,
   Shape,
@@ -42,5 +44,6 @@ const exportedTypeSuite: t.ITypeSuite = {
   Circle,
   MixedArray,
   ArrayUnion,
+  UnionWithUnnamedArray,
 };
 export default exportedTypeSuite;

--- a/test/test_checker.ts
+++ b/test/test_checker.ts
@@ -737,7 +737,7 @@ function suite() {
   });
 
   it("should name array types in error messages", () => {
-    const {MixedArray, ArrayUnion} = createCheckers(enumUnionTI);
+    const {MixedArray, ArrayUnion, UnionWithUnnamedArray} = createCheckers(enumUnionTI);
 
     MixedArray.check(['one', 'two', 'three']);
     MixedArray.check(['one', 'two', 'three']);
@@ -748,6 +748,11 @@ function suite() {
     ArrayUnion.check([1, 2, 3]);
     ArrayUnion.check([true, false]);
     assert.throws(() => ArrayUnion.check([undefined]), "value is none of string[], boolean[], number[], string[][]");
+
+    UnionWithUnnamedArray.check(['one', 'two', 'three']);
+    UnionWithUnnamedArray.check([1, 2, 3]);
+    UnionWithUnnamedArray.check(['one', false]);
+    assert.throws(() => UnionWithUnnamedArray.check([undefined]), "value is none of string[], number[], 1 more; value[0] is none of string, boolean");
   });
 
 };

--- a/test/test_checker.ts
+++ b/test/test_checker.ts
@@ -337,21 +337,21 @@ function suite() {
       }
     })
 
-    assert.throws(() => 
+    assert.throws(() =>
         SameKeyIntersection.check({
           x: {
             foo: 'foo',
           }
         }), /bar is missing/);
 
-    assert.throws(() => 
+    assert.throws(() =>
         SameKeyIntersection.check({
           x: {
             bar: 1,
           }
         }), /foo is missing/);
 
-    assert.throws(() => 
+    assert.throws(() =>
         SameKeyIntersection.check({
           x: {
             foo: 1,
@@ -735,6 +735,21 @@ function suite() {
       {"path": "value.c", "message": "is missing"},
     );
   });
+
+  it("should name array types in error messages", () => {
+    const {MixedArray, ArrayUnion} = createCheckers(enumUnionTI);
+
+    MixedArray.check(['one', 'two', 'three']);
+    MixedArray.check(['one', 'two', 'three']);
+    MixedArray.check([1, 'two', 3]);
+    assert.throws(() => MixedArray.check([undefined]), "value[0] is none of string, number, string[]");
+
+    ArrayUnion.check(['one', 'two', 'three']);
+    ArrayUnion.check([1, 2, 3]);
+    ArrayUnion.check([true, false]);
+    assert.throws(() => ArrayUnion.check([undefined]), "value is none of string[], boolean[], number[], string[][]");
+  });
+
 };
 
 


### PR DESCRIPTION
### Goal:

Add `name` to Array types to have cleaner validation errors.

### Description:

Currently validating against a type like `export type ArrayUnion = string[] | boolean[] | number[] | string[][]` results in rather nondescript messages like `value is none of 4 types`

### Changes

- If array element's type has a `name` - array name is set to `elementName[]`
- If array element's type doesn't have a `name` - array name is not set

Note: this is a targeted fix for a specific case, there's still things that fall into "other types", e.g. `(string | number)[]`

### Result

New error message now says `value is none of string[], boolean[], number[], string[][]`
