### PR TITLE
Update readme example not to break `const`

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ const checker = createCheckers(fooTI) as {Square: CheckerT<Square>};
 
 const unk: unknown = {size: 1, color: "green"};
 
-if (checker.Square.test(unk)) {
+if (checkers.Square.test(unk)) {
   // TypeScript is now aware that unk implements Square, and allows member access.
   console.log(unk.size);
 }

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ import {Square} from "./foo";
 import fooTI from "./foo-ti";
 import {createCheckers, CheckerT} from "ts-interface-checker";
 
-const checker = createCheckers(fooTI) as {Square: CheckerT<Square>};
+const checkers = createCheckers(fooTI) as {Square: CheckerT<Square>};
 
 const unk: unknown = {size: 1, color: "green"};
 

--- a/README.md
+++ b/README.md
@@ -169,11 +169,11 @@ import {Square} from "./foo";
 import fooTI from "./foo-ti";
 import {createCheckers, CheckerT} from "ts-interface-checker";
 
-const {Square} = createCheckers(fooTI) as {Square: CheckerT<Square>};
+const checker = createCheckers(fooTI) as {Square: CheckerT<Square>};
 
 const unk: unknown = {size: 1, color: "green"};
 
-if (Square.test(unk)) {
+if (checker.Square.test(unk)) {
   // TypeScript is now aware that unk implements Square, and allows member access.
   console.log(unk.size);
 }


### PR DESCRIPTION
I noticed that the last example in readme has a trouble.
`Square` is already declared as `import {Square} from "./foo";`, so we can't redefine `const {Square} = ...` again.
I chose name `checker` without giving it much thought; please fix it with more appropriate one.